### PR TITLE
HTML形式のAPIリファレンスに論理名の列を追加

### DIFF
--- a/DeviceConnectCodegen/RELEASENOTE.TXT
+++ b/DeviceConnectCodegen/RELEASENOTE.TXT
@@ -1,4 +1,7 @@
 # 変更履歴
+2017/06/23: v1.3.0 [Markdown] DeviceConnectAPIリファレンス生成機能を追加
+                   [HTML] レスポンス・イベントのパラメータの説明に「Logical Name」を追加
+
 2017/04/03: v1.2.0 [HTML] DeviceConnectAPIリファレンス生成機能を追加
 
 2017/03/24: v1.1.0 [NodeJS] DeviceConnectエミュレータのスケルトン生成機能を追加

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/pom.xml
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.deviceconnect</groupId>
     <artifactId>deviceconnect-codegen</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
 
     <packaging>jar</packaging>
 

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/resources/deviceConnectHtmlDocs/dconnect-message.mustache
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/resources/deviceConnectHtmlDocs/dconnect-message.mustache
@@ -1,8 +1,8 @@
 <table>
     <tbody>
-        <tr><th colspan="{{maxNestLevel}}">Name</th><th>Type</th><th>Required</th><th>Description</th></tr>
+        <tr><th colspan="{{maxNestLevel}}">Logical Name</th><th>Physical Name</th><th>Type</th><th>Required</th><th>Description</th></tr>
         {{#paramList}}
-        <tr>{{#indents}}<td></td>{{/indents}}<td colspan="{{colSpan}}" class="mono">{{name}}</td><td>{{dataType}}</td><td>{{required}}</td><td>{{#title}}<b>{{{.}}}</b><br>{{/title}}{{{description}}}</td></tr>
+        <tr>{{#indents}}<td></td>{{/indents}}<td colspan="{{colSpan}}" class="mono">{{title}}</td><td>{{name}}</td><td>{{dataType}}</td><td>{{required}}</td><td>{{{description}}}</td></tr>
         {{/paramList}}
     </tbody>
 </table>

--- a/DeviceConnectCodegen/pom.xml
+++ b/DeviceConnectCodegen/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.deviceconnect</groupId>
     <artifactId>deviceconnect-codegen-project</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
 
     <packaging>pom</packaging>
 


### PR DESCRIPTION
## 修正内容
DeviceConnect Codegenの出力するHTML形式のAPIリファレンスについて、レスポンス・イベントのパラメータ定義表に論理名を示す「Logical Name」を追加する。