### PR TITLE
ADBプラグインビルド時のSDKの参照パス修正

### DIFF
--- a/dConnectDeviceADB/plugin/build.gradle
+++ b/dConnectDeviceADB/plugin/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 dependencies {
     compile fileTree(include: '*.jar', dir: 'libs')
-    compile project(':dconnect-device-plugin-sdk')
+    compile 'org.deviceconnect:dconnect-device-plugin-sdk:2.2.3'
     compile 'io.airlift:airline:0.7'
 
     testCompile 'junit:junit:4.12'

--- a/dConnectDeviceADB/settings.gradle
+++ b/dConnectDeviceADB/settings.gradle
@@ -1,5 +1,1 @@
 include ':plugin'
-include 'dconnect-sdk-for-android'
-project(':dconnect-sdk-for-android').projectDir = new File('../../DeviceConnect-Android/dConnectSDK/dConnectSDKForAndroid/dconnect-sdk-for-android')
-include 'dconnect-device-plugin-sdk'
-project(':dconnect-device-plugin-sdk').projectDir = new File('../../DeviceConnect-Android/dConnectDevicePlugin/dConnectDevicePluginSDK/dconnect-device-plugin-sdk')


### PR DESCRIPTION
## 修正内容
* ADBプラグインをビルドするときにSDKの参照パスが環境に依存していたため、その修正を行なった。