### PR TITLE
ADBプラグインの設定画面上での異常系処理を修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -303,3 +303,6 @@ ant.properties
 build.xml
 HVCW.jar
 RobotLibrary.jar
+
+### dConnectDeviceADB ###
+**/dist/*

--- a/dConnectDeviceADB/gradle-default.properties
+++ b/dConnectDeviceADB/gradle-default.properties
@@ -1,0 +1,4 @@
+storeFile=/path/to/storeFile
+storePassword=YOUR_STORE_PASSWORD
+keyAlias=YOUR_KEY_ALIAS
+keyPassword=YOUR_KEY_PASSWORD

--- a/dConnectDeviceADB/plugin/build.gradle
+++ b/dConnectDeviceADB/plugin/build.gradle
@@ -65,3 +65,36 @@ android {
         options.encoding = 'UTF-8'
     }
 }
+
+def distRootDir = '../dist'
+def distDir = distRootDir + '/dConnectDeviceADB'
+task cleanDist(type: Delete) {
+    delete distRootDir
+}
+task assembleDistRelease(dependsOn: ['assembleRelease', 'copyRelease', 'copySource']) {
+}
+task assembleDistDebug(dependsOn: ['assembleDebug', 'copyDebug', 'copySource']) {
+}
+task copyRelease(type: Copy) {
+    from 'build/outputs/apk'
+    into distDir
+    include '**/plugin-release.apk'
+    rename 'plugin-release.apk', 'dConnectDeviceADB.apk'
+}
+task copyDebug(type: Copy) {
+    from 'build/outputs/apk'
+    into distDir
+    include '**/plugin-debug.apk'
+    rename 'plugin-debug.apk', 'dConnectDeviceADB-debug.apk'
+}
+task copySource(type: Copy) {
+    from '../'
+    into distDir + '/src/dConnectDeviceADB'
+    exclude '**/build/**/*'
+    exclude '**/dist/**/*'
+    exclude '**/gradle.properties'
+    exclude '**/local.properties'
+    exclude '**/*.apk'
+    includeEmptyDirs false
+    rename 'gradle-default.properties', 'gradle.properties'
+}

--- a/dConnectDeviceADB/plugin/src/main/java/org/deviceconnect/android/deviceplugin/adb/core/AdbApplication.java
+++ b/dConnectDeviceADB/plugin/src/main/java/org/deviceconnect/android/deviceplugin/adb/core/AdbApplication.java
@@ -3,7 +3,12 @@ package org.deviceconnect.android.deviceplugin.adb.core;
 
 import android.app.Application;
 
+import org.deviceconnect.android.deviceplugin.adb.BuildConfig;
+import org.deviceconnect.android.logger.AndroidHandler;
+
+import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
 
 
 public class AdbApplication extends Application {
@@ -15,6 +20,16 @@ public class AdbApplication extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
+
+        if (BuildConfig.DEBUG) {
+            AndroidHandler handler = new AndroidHandler(mLogger.getName());
+            handler.setFormatter(new SimpleFormatter());
+            handler.setLevel(Level.ALL);
+            mLogger.addHandler(handler);
+            mLogger.setLevel(Level.ALL);
+        } else {
+            mLogger.setLevel(Level.OFF);
+        }
 
         mConnectionMgr = new ConnectionManager(getApplicationContext(), mLogger);
     }

--- a/dConnectDeviceADB/plugin/src/main/java/org/deviceconnect/android/deviceplugin/adb/fragment/AdbSettingFragment.java
+++ b/dConnectDeviceADB/plugin/src/main/java/org/deviceconnect/android/deviceplugin/adb/fragment/AdbSettingFragment.java
@@ -1,10 +1,14 @@
 package org.deviceconnect.android.deviceplugin.adb.fragment;
 
 import android.app.Activity;
+import android.content.Context;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.v4.app.Fragment;
+import android.text.Editable;
+import android.text.TextUtils;
+import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -23,6 +27,8 @@ import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.util.Enumeration;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 
 public class AdbSettingFragment extends Fragment implements ConnectionListener {
@@ -32,12 +38,51 @@ public class AdbSettingFragment extends Fragment implements ConnectionListener {
         EDIT
     }
 
+    private enum Ipv4AddressError {
+        EMPTY(R.string.setting_error_empty),
+        INVALID_FORMAT(R.string.setting_error_ip_address_invalid_format),
+        NOT_ALLOWED_ZERO_PADDING(R.string.setting_error_not_allowed_zero_padding),
+        ALREADY_ADDED(R.string.setting_error_already_connected);
+
+        private int mMessageId;
+
+        Ipv4AddressError(final int messageId) {
+            mMessageId = messageId;
+        }
+
+        public String getMessage(final Context context) {
+            return context.getString(mMessageId);
+        }
+    }
+
+    private enum PortNumberError {
+        EMPTY(R.string.setting_error_empty),
+        OUT_OF_RANGE(R.string.setting_error_port_number_out_of_range);
+        // INVALID_FORMAT //NOTE: 数字であることはUIコンポーネント側の設定で保証する
+
+        private int mMessageId;
+
+        PortNumberError(final int messageId) {
+            mMessageId = messageId;
+        }
+
+        public String getMessage(final Context context) {
+            return context.getString(mMessageId);
+        }
+    }
+
     public static final String EXTRA_MODE = "mode";
     public static final String EXTRA_IP_ADDRESS = "ip_address";
     public static final String EXTRA_PORT = "port";
 
+    private static final Pattern IPV4_ADDRESS_PATTERN = Pattern.compile("^\\d+\\.\\d+\\.\\d+\\.\\d+$");
+    private static final String LOCALHOST = "localhost";
+
+    private Mode mMode;
     private EditText mIpAddressEditor;
     private EditText mPortNumEditor;
+    private Button mConnectionAddButton;
+    private Button mConnectionChangeButton;
 
     private ConnectionManager mConnectionMgr;
     private Handler mHandler;
@@ -54,46 +99,32 @@ public class AdbSettingFragment extends Fragment implements ConnectionListener {
         mConnectionMgr.addListener(this);
 
         Bundle args = getArguments();
-        Mode mode = (Mode) args.getSerializable(EXTRA_MODE);
-        if (mode == null) {
-            mode = Mode.ADD;
+        mMode = (Mode) args.getSerializable(EXTRA_MODE);
+        if (mMode == null) {
+            mMode = Mode.ADD;
         }
-        String ipAddressParam = args.getString(EXTRA_IP_ADDRESS);
-        String portParam = args.getString(EXTRA_PORT);
 
         mIpAddressEditor = (EditText) root.findViewById(R.id.edit_text_ip_address);
-        if (mode != Mode.ADD) {
+        if (mMode != Mode.ADD) {
             mIpAddressEditor.setEnabled(false);
-        }
-        if (ipAddressParam != null) {
-            mIpAddressEditor.setText(ipAddressParam);
         }
 
         mPortNumEditor = (EditText) root.findViewById(R.id.edit_text_port_number);
-        if (portParam != null) {
-            mPortNumEditor.setText(portParam);
-        }
 
-        Button connectionAddButton = (Button) root.findViewById(R.id.button_connection_add);
-        connectionAddButton.setOnClickListener(new View.OnClickListener() {
+        mConnectionAddButton = (Button) root.findViewById(R.id.button_connection_add);
+        mConnectionAddButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(final View view) {
                 final String ip = getIpAddressParam();
                 final int portNum = getPortNumberParam();
-
-                Connection cache = mConnectionMgr.getConnection(ip);
-                if (cache != null) {
-                    showAlreadyConnectedDialog(ip);
-                } else {
-                    mConnectionMgr.addConnection(ip, portNum);
-                    prompt(Mode.ADD, ip, portNum);
-                }
+                mConnectionMgr.addConnection(ip, portNum);
+                prompt(Mode.ADD, ip, portNum);
             }
         });
-        connectionAddButton.setVisibility(mode == Mode.ADD ? View.VISIBLE : View.GONE);
+        mConnectionAddButton.setVisibility(mMode == Mode.ADD ? View.VISIBLE : View.GONE);
 
-        Button connectionChangeButton = (Button) root.findViewById(R.id.button_connection_change);
-        connectionChangeButton.setOnClickListener(new View.OnClickListener() {
+        mConnectionChangeButton = (Button) root.findViewById(R.id.button_connection_change);
+        mConnectionChangeButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(final View view) {
                 final String ip = getIpAddressParam();
@@ -117,8 +148,129 @@ public class AdbSettingFragment extends Fragment implements ConnectionListener {
                 }
             }
         });
-        connectionChangeButton.setVisibility(mode == Mode.EDIT ? View.VISIBLE : View.GONE);
+        mConnectionChangeButton.setVisibility(mMode == Mode.EDIT ? View.VISIBLE : View.GONE);
+
+        // 指定された設定を表示
+        String ipAddressParam = args.getString(EXTRA_IP_ADDRESS);
+        String portParam = args.getString(EXTRA_PORT);
+        if (ipAddressParam != null) {
+            mIpAddressEditor.setText(ipAddressParam);
+        }
+        if (portParam != null) {
+            mPortNumEditor.setText(portParam);
+        }
+
+        // 設定変更リスナーの初期化
+        mIpAddressEditor.addTextChangedListener(new DefaultTextWatcher() {
+            @Override
+            public void onTextChanged(final CharSequence text, final int start, final int before, final int count) {
+                showInputError();
+            }
+        });
+        mPortNumEditor.addTextChangedListener(new DefaultTextWatcher() {
+            @Override
+            public void onTextChanged(final CharSequence text, final int start, final int before, final int count) {
+                showInputError();
+            }
+        });
+
+        // エラー表示初期化
+        showInputError();
+
         return root;
+    }
+
+    private void showInputError() {
+        boolean hasError = showIpv4AddressError(getIpAddressParam()) ||
+                           showPortNumberError(mPortNumEditor.getText().toString());
+        enableButton(!hasError);
+    }
+
+    private void enableButton(final boolean isEnabled) {
+        mConnectionAddButton.setEnabled(isEnabled);
+        mConnectionChangeButton.setEnabled(isEnabled);
+    }
+
+    private boolean showIpv4AddressError(final CharSequence input) {
+        Ipv4AddressError error = checkIpv4Address(input);
+        if (error != null) {
+            mIpAddressEditor.setError(error.getMessage(getContext()));
+            return true;
+        }
+        return false;
+    }
+
+    private boolean showPortNumberError(final CharSequence input) {
+        PortNumberError error = checkPortNumber(input);
+        if (error != null) {
+            mPortNumEditor.setError(error.getMessage(getContext()));
+            return true;
+        }
+        return false;
+    }
+
+    private Ipv4AddressError checkIpv4Address(final CharSequence input) {
+        // 未指定でないこと
+        if (TextUtils.isEmpty(input)) {
+            return Ipv4AddressError.EMPTY;
+        }
+        String str = input.toString();
+
+        // 4つの要素で分割されること
+        Matcher matcher = IPV4_ADDRESS_PATTERN.matcher(input);
+        if (!matcher.matches()) {
+            return Ipv4AddressError.INVALID_FORMAT;
+        }
+        try {
+            String[] parts = str.split("\\.");
+
+            // 各要素が 0 以上 255 以下であること
+            for (String p : parts) {
+                int part = Integer.parseInt(p);
+                if (part < 0 || part > 255) {
+                    return Ipv4AddressError.INVALID_FORMAT;
+                }
+            }
+
+            // ゼロパディングされていないこと (曖昧さの回避のため)
+            for (String p : parts) {
+                if (p.length() > 1 && p.startsWith("0")) {
+                    return Ipv4AddressError.NOT_ALLOWED_ZERO_PADDING;
+                }
+            }
+        } catch (NumberFormatException e) {
+            return Ipv4AddressError.INVALID_FORMAT;
+        }
+
+        // 新規追加の場合は、IPv4アドレスが未登録のものであること
+        if (mMode == Mode.ADD) {
+            Connection cache = mConnectionMgr.getConnection(str);
+            if (cache != null) {
+                return Ipv4AddressError.ALREADY_ADDED;
+            }
+        }
+
+        return null;
+    }
+
+    private PortNumberError checkPortNumber(final CharSequence input) {
+        // 未指定でないこと
+        if (TextUtils.isEmpty(input)) {
+            return PortNumberError.EMPTY;
+        }
+
+        // 1024 以上 65535 以下であること
+        try {
+            int portNum = Integer.parseInt(input.toString());
+            if (portNum < 1024 || portNum > 65535) {
+                return PortNumberError.OUT_OF_RANGE;
+            }
+        } catch (NumberFormatException e) {
+            // NOTE: Integer.MAX_VALUE を超える値が指定された場合に発生
+            return PortNumberError.OUT_OF_RANGE;
+        }
+
+        return null;
     }
 
     @Override
@@ -163,7 +315,9 @@ public class AdbSettingFragment extends Fragment implements ConnectionListener {
      * @return ホストデバイスのアドレスである場合はtrue. そうでない場合はfalse.
      */
     private boolean isLocalAddress(final String ipv4Address) {
-        if (Connection.LOOPBACK_ADDRESS.equals(ipv4Address) ||  "0.0.0.0".equals(ipv4Address)) {
+        if (LOCALHOST.equals(ipv4Address) ||
+            Connection.LOOPBACK_ADDRESS.equals(ipv4Address) ||
+            "0.0.0.0".equals(ipv4Address)) {
             return true;
         }
         try {
@@ -198,14 +352,6 @@ public class AdbSettingFragment extends Fragment implements ConnectionListener {
         if (activity != null) {
             activity.finish();
         }
-    }
-
-    private void showAlreadyConnectedDialog(final String ipAddress) {
-        String message = getString(R.string.setting_error_dialog_message_already_connected);
-        message = message.replace("{{target}}", ipAddress);
-
-        ErrorDialogFragment dialog = createErrorDialog(message);
-        dialog.show(getFragmentManager(), "dialog");
     }
 
     private ErrorDialogFragment createErrorDialog(final String message) {
@@ -281,5 +427,19 @@ public class AdbSettingFragment extends Fragment implements ConnectionListener {
     @Override
     public void onRemoved(final Connection connection) {
         // NOP.
+    }
+
+    private abstract class DefaultTextWatcher implements TextWatcher {
+        @Override
+        public void beforeTextChanged(final CharSequence text, final int start, final int count, final int after) {
+        }
+
+        @Override
+        public void onTextChanged(final CharSequence text, final int start, final int before, final int count) {
+        }
+
+        @Override
+        public void afterTextChanged(final Editable editor) {
+        }
     }
 }

--- a/dConnectDeviceADB/plugin/src/main/res/drawable/button_blue.xml
+++ b/dConnectDeviceADB/plugin/src/main/res/drawable/button_blue.xml
@@ -1,5 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:state_enabled="false">
+        <shape android:shape="rectangle" android:useLevel="false">
+            <solid android:color="@android:color/darker_gray"/>
+            <stroke
+                android:color="#CCCCCC"
+                android:width="1dp"/>
+
+            <corners
+                android:radius="10dp"/>
+        </shape>
+    </item>
+
     <item android:state_pressed="true">
         <shape android:shape="rectangle" android:useLevel="false">
             <solid android:color="@android:color/darker_gray"/>

--- a/dConnectDeviceADB/plugin/src/main/res/layout/fragment_setting.xml
+++ b/dConnectDeviceADB/plugin/src/main/res/layout/fragment_setting.xml
@@ -27,8 +27,9 @@
             android:id="@+id/edit_text_ip_address"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:hint="@string/setting_item_ip_address_hint"
-            android:text="@string/setting_item_ip_address_default" />
+            android:inputType="text"
+            android:digits="0123456789.abcdefghijklmnopqrstuvwxyz"
+            android:hint="@string/setting_item_ip_address_hint" />
 
     </LinearLayout>
 

--- a/dConnectDeviceADB/plugin/src/main/res/values/strings.xml
+++ b/dConnectDeviceADB/plugin/src/main/res/values/strings.xml
@@ -6,7 +6,6 @@
     <string name="setting_description" translatable="false">ADB接続先の情報を入力してください。</string>
     <string name="setting_item_ip_address_title" translatable="false">IPアドレス:</string>
     <string name="setting_item_ip_address_hint" translatable="false">192.168.1.x</string>
-    <string name="setting_item_ip_address_default" translatable="false">192.168.1.x</string>
     <string name="setting_item_port_number_title" translatable="false">ポート番号:</string>
     <string name="setting_item_port_number_hint" translatable="false">5555</string>
     <string name="setting_item_port_number_default" translatable="false">5555</string>
@@ -17,7 +16,11 @@
     <string name="setting_prompt_dialog_title" translatable="false">接続確認</string>
     <string name="setting_prompt_dialog_message_for_new_service" translatable="false">"サービスを{{operation}}しました。現在サービスはオフラインです。\n\n次の手順でADB接続してください。（このダイアログを閉じてからでも可）\n\n1. Android端末とPCをUSB接続。\n2. PCのターミナル上で adb tcpip {{port}} を実行。\n3. 約3秒後、Android端末上に「USBデバッグを許可しますか？」と表示された場合は「OK」を選択。</string>
     <string name="setting_error_dialog_title" translatable="false">エラー</string>
-    <string name="setting_error_dialog_message_already_connected" translatable="false">IPアドレス {{target}} はすでに追加されています。\n\nポート番号を変更したい場合はサービス一覧でサービスを選択し、編集画面を開いてください。</string>
+    <string name="setting_error_already_connected" translatable="false">既に追加されています</string>
+    <string name="setting_error_empty" translatable="false">未指定です</string>
+    <string name="setting_error_ip_address_invalid_format" translatable="false">例: 192.168.1.1</string>
+    <string name="setting_error_not_allowed_zero_padding" translatable="false">先頭のゼロを削除</string>
+    <string name="setting_error_port_number_out_of_range" translatable="false">1024〜65535の範囲で指定</string>
     <string name="setting_message_adb_connection_success" translatable="false">{{target}} とADB接続完了</string>
 
 </resources>


### PR DESCRIPTION
#  修正内容
ADBプラグインの設定画面について、下記のように改修しました。

・「IPアドレス」にIPv4アドレス以外の文字列を指定できないように変更しました。
ただし、localhost は特例として指定可能です。
不正な文字列が指定された場合は、エラーメッセージが表示され、「追加」が押せないようになります。

・「ポート番号」を空にした状態で「追加」を押すと異常終了する不具合の修正。